### PR TITLE
Updated plugin to support CDNs

### DIFF
--- a/lib/helper/sfCombineHelper.php
+++ b/lib/helper/sfCombineHelper.php
@@ -146,10 +146,10 @@ function get_combined_javascripts(
       {
         $temp = javascript_include_tag($file,$fileDetails['options']);
         $html .= preg_replace('/"\/js/','"'.$cdn['protocol'].$cdn['host'].'/js',$temp);  
-        $html = preg_replace('/<script /','<script async defer ',$html);
+        //$html = preg_replace('/<script /','<script async defer ',$html);
       } else {
         $html .= javascript_include_tag($file,$fileDetails['options']);
-        $html = preg_replace('/<script /','<script async defer ',$html);
+        //$html = preg_replace('/<script /','<script async defer ',$html);
       }
     } else {
 
@@ -163,10 +163,10 @@ function get_combined_javascripts(
         $temp = javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
         $html .= preg_replace('/"\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp); 
         //$html .= preg_replace('/"\/frontend_dev.php\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp);
-        $html = preg_replace('/<script /','<script async defer ',$temp);
+        //$html = preg_replace('/<script /','<script async defer ',$temp);
       } else {
         $html .= javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
-        $html = preg_replace('/<script /','<script async defer ',$html);
+        //$html = preg_replace('/<script /','<script async defer ',$html);
       }
       
     }

--- a/lib/helper/sfCombineHelper.php
+++ b/lib/helper/sfCombineHelper.php
@@ -146,8 +146,10 @@ function get_combined_javascripts(
       {
         $temp = javascript_include_tag($file,$fileDetails['options']);
         $html .= preg_replace('/"\/js/','"'.$cdn['protocol'].$cdn['host'].'/js',$temp);  
+        $html = preg_replace('/<script /','<script async defer ',$html);
       } else {
         $html .= javascript_include_tag($file,$fileDetails['options']);
+        $html = preg_replace('/<script /','<script async defer ',$html);
       }
     } else {
 

--- a/lib/helper/sfCombineHelper.php
+++ b/lib/helper/sfCombineHelper.php
@@ -159,7 +159,9 @@ function get_combined_javascripts(
       if($cdn['enabled'])
       {
         $temp = javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
-        $html .= preg_replace('/"\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp); 
+        //$html .= preg_replace('/"\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp); 
+        $html .= preg_replace('/"\/frontend_dev.php\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp);
+        $html = preg_replace('/<script /','<script async ',$html);
       } else {
         $html .= javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
       }

--- a/lib/helper/sfCombineHelper.php
+++ b/lib/helper/sfCombineHelper.php
@@ -159,11 +159,12 @@ function get_combined_javascripts(
       if($cdn['enabled'])
       {
         $temp = javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
-        //$html .= preg_replace('/"\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp); 
-        $html .= preg_replace('/"\/frontend_dev.php\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp);
-        $html = preg_replace('/<script /','<script async ',$html);
+        $html .= preg_replace('/"\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp); 
+        //$html .= preg_replace('/"\/frontend_dev.php\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp);
+        $html = preg_replace('/<script /','<script async ',$temp);
       } else {
         $html .= javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
+        $html = preg_replace('/<script /','<script async ',$html);
       }
       
     }

--- a/lib/helper/sfCombineHelper.php
+++ b/lib/helper/sfCombineHelper.php
@@ -130,21 +130,13 @@ function get_combined_javascripts(
 
       $file = $fileDetails['files'];
 
-      if (
-        isset($timestampConfig['uncombinable'])
-        &&
-        $timestampConfig['uncombinable']
-        &&
-        $fileDetails['timestamp']
-      )
+      if (isset($timestampConfig['uncombinable']) && $timestampConfig['uncombinable'] && $fileDetails['timestamp'])
       {
         // add timestamp
         if (strpos($file, '?') !== false)
         {
           $file .= '&t=' . $fileDetails['timestamp'];
-        }
-        else
-        {
+        } else {
           $file .= '?t=' . $fileDetails['timestamp'];
         }
       }
@@ -153,25 +145,25 @@ function get_combined_javascripts(
       if($cdn['enabled'])
       {
         $temp = javascript_include_tag($file,$fileDetails['options']);
-        $html .= preg_replace('/"\/js/','"'.$cdn['protocol'].$cdn['host'].'/js',$temp);
+        $html .= preg_replace('/"\/js/','"'.$cdn['protocol'].$cdn['host'].'/js',$temp);  
       } else {
         $html .= javascript_include_tag($file,$fileDetails['options']);
       }
-    }
-    else
-    {
+    } else {
 
       $route = isset($config['route']) ? $config['route'] : 'sfCombine';
 
-      $html .= javascript_include_tag(
-        url_for(
-          '@' . $route . '?module=sfCombine&action=js&'
-          . sfCombineUrl::getUrlString(
-            $fileDetails['files'], $fileDetails['timestamp']
-          )
-        ),
-        $fileDetails['options']
-      );
+      $js_config = sfConfig::get('app_sfCombinePlugin_js');
+      $cdn = $js_config['cdn'];
+
+      if($cdn['enabled'])
+      {
+        $temp = javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
+        $html .= preg_replace('/"\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp); 
+      } else {
+        $html .= javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
+      }
+      
     }
   }
   
@@ -299,21 +291,19 @@ function get_combined_stylesheets(
         $html .= stylesheet_tag($file,$fileDetails['options']);
     }
 
-    } 
-    else
-    {
+    }  else {
 
       $route = isset($config['route']) ? $config['route'] : 'sfCombine';
 
-      $html .= stylesheet_tag(
-        url_for(
-          '@' . $route . '?module=sfCombine&action=css&'
-          . sfCombineUrl::getUrlString(
-              $fileDetails['files'], $fileDetails['timestamp']
-            )
-        ),
-        $fileDetails['options']
-      );
+      $css_config = sfConfig::get('app_sfCombinePlugin_css');
+      $cdn = $css_config['cdn'];
+      if($cdn['enabled'])
+      {
+        $temp = stylesheet_tag(url_for('@' . $route . '?module=sfCombine&action=css&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
+        $html .= preg_replace('/"\/css/','"'.$cdn['protocol'].$cdn['host'].'/css',$temp);
+      } else {
+        $html .= stylesheet_tag(url_for('@' . $route . '?module=sfCombine&action=css&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
+      }
     }
   }
 

--- a/lib/helper/sfCombineHelper.php
+++ b/lib/helper/sfCombineHelper.php
@@ -153,7 +153,7 @@ function get_combined_javascripts(
       if($cdn['enabled'])
       {
         $temp = javascript_include_tag($file,$fileDetails['options']);
-        $html .= preg_replace('/"\/js/','"//'.$cdn['host'].'/js',$temp);
+        $html .= preg_replace('/"\/js/','"'.$cdn['protocol'].$cdn['host'].'/js',$temp);
       } else {
         $html .= javascript_include_tag($file,$fileDetails['options']);
       }
@@ -294,7 +294,7 @@ function get_combined_stylesheets(
       if($cdn['enabled'])
       {
         $temp = stylesheet_tag($file,$fileDetails['options']);
-        $html .= preg_replace('/"\/css/','"//'.$cdn['host'].'/css',$temp);
+        $html .= preg_replace('/"\/css/','"'.$cdn['protocol'].$cdn['host'].'/css',$temp);
       } else {
         $html .= stylesheet_tag($file,$fileDetails['options']);
     }

--- a/lib/helper/sfCombineHelper.php
+++ b/lib/helper/sfCombineHelper.php
@@ -161,10 +161,10 @@ function get_combined_javascripts(
         $temp = javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
         $html .= preg_replace('/"\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp); 
         //$html .= preg_replace('/"\/frontend_dev.php\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp);
-        $html = preg_replace('/<script /','<script async ',$temp);
+        $html = preg_replace('/<script /','<script async defer ',$temp);
       } else {
         $html .= javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
-        $html = preg_replace('/<script /','<script async ',$html);
+        $html = preg_replace('/<script /','<script async defer ',$html);
       }
       
     }

--- a/lib/helper/sfCombineHelper.php
+++ b/lib/helper/sfCombineHelper.php
@@ -300,7 +300,7 @@ function get_combined_stylesheets(
       if($cdn['enabled'])
       {
         $temp = stylesheet_tag(url_for('@' . $route . '?module=sfCombine&action=css&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
-        $html .= preg_replace('/"\/css/','"'.$cdn['protocol'].$cdn['host'].'/css',$temp);
+        $html .= preg_replace('/"\/css-min/','"'.$cdn['protocol'].$cdn['host'].'/css-min',$temp);
       } else {
         $html .= stylesheet_tag(url_for('@' . $route . '?module=sfCombine&action=css&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
       }

--- a/lib/helper/sfCombineHelper.php
+++ b/lib/helper/sfCombineHelper.php
@@ -148,11 +148,15 @@ function get_combined_javascripts(
           $file .= '?t=' . $fileDetails['timestamp'];
         }
       }
-
-      $html .= javascript_include_tag(
-        $file,
-        $fileDetails['options']
-      );
+      $js_config = sfConfig::get('app_sfCombinePlugin_js');
+      $cdn = $js_config['cdn'];
+      if($cdn['enabled'])
+      {
+        $temp = javascript_include_tag($file,$fileDetails['options']);
+        $html .= preg_replace('/"\/js/','"//'.$cdn['host'].'/js',$temp);
+      } else {
+        $html .= javascript_include_tag($file,$fileDetails['options']);
+      }
     }
     else
     {
@@ -285,11 +289,15 @@ function get_combined_stylesheets(
           $file .= '?t=' . $fileDetails['timestamp'];
         }
       }
-
-      $html .= stylesheet_tag(
-        $file,
-        $fileDetails['options']
-      );
+      $css_config = sfConfig::get('app_sfCombinePlugin_css');
+      $cdn = $css_config['cdn'];
+      if($cdn['enabled'])
+      {
+        $temp = stylesheet_tag($file,$fileDetails['options']);
+        $html .= preg_replace('/"\/css/','"//'.$cdn['host'].'/css',$temp);
+      } else {
+        $html .= stylesheet_tag($file,$fileDetails['options']);
+    }
 
     } 
     else

--- a/lib/helper/sfCombineHelper.php
+++ b/lib/helper/sfCombineHelper.php
@@ -161,8 +161,8 @@ function get_combined_javascripts(
       if($cdn['enabled'])
       {
         $temp = javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);
-        $html .= preg_replace('/"\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp); 
-        //$html .= preg_replace('/"\/frontend_dev.php\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp);
+        //$html .= preg_replace('/"\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp); 
+        $html .= preg_replace('/"\/js-min/','"'.$cdn['protocol'].$cdn['host'].'/js-min',$temp);
         //$html = preg_replace('/<script /','<script async defer ',$temp);
       } else {
         $html .= javascript_include_tag(url_for('@' . $route . '?module=sfCombine&action=js&'. sfCombineUrl::getUrlString($fileDetails['files'], $fileDetails['timestamp'])),$fileDetails['options']);


### PR DESCRIPTION
I've added some app settings and change the code in the helper to support the use of CDNs with sfCombinePlugin

In app

under each section (JS & CSS)

cdn:
        enabled: true     # true if using a CDN or false if not
        host: cdn.example.com #the CDN host address
        protocol: //  #http:// for straight http://, https:// for straight https or // to determined by page

Working on ProdPad using CloudFront as the CDN.
